### PR TITLE
feat(): added a retry condition for opening cameras

### DIFF
--- a/barcodescanner/src/main/java/com/google/zxing/client/android/camera/open/OpenCameraInterface.java
+++ b/barcodescanner/src/main/java/com/google/zxing/client/android/camera/open/OpenCameraInterface.java
@@ -72,10 +72,21 @@ public final class OpenCameraInterface {
       }
     }
 
-    Camera camera;
+    Camera camera = null;
     if (index < numCameras) {
-      Log.i(TAG, "Opening camera #" + index);
-      camera = Camera.open(index);
+      do {
+          Log.i(TAG, "Opening camera #" + index);
+          try {
+            camera = Camera.open(index);
+          } catch (RuntimeException re) {
+             Log.i(TAG, "Failed opening camera #" + index);
+             if (index >= numCameras - 1) {
+               throw re;
+             } else {
+               index++;
+             }
+          }
+      } while (camera == null);
     } else {
       if (explicitRequest) {
         Log.w(TAG, "Requested camera does not exist: " + cameraId);


### PR DESCRIPTION
openCamera will now try to open the next camera if the first open camera operation fails, it will retry until no other camera with a higher index exists.
This alleviates behaviour on some multi-backfacing camera phones where initial opening of camera 0 fails at runtime.